### PR TITLE
Fix default version regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 |Name|Description|Required|Default|
 |:---|:----------|:------:|:-----:|
 |`token`<sup>1</sup>|GitHub token, required for permission to create a tag|yes||
-|`version_regex`|the version regex to use for detecting version in commit messages|no|`'[0-9]+.[0-9]+.[0-9]+'`|
+|`version_regex`|the version regex to use for detecting version in commit messages|no|`'^[0-9]+\.[0-9]+\.[0-9]+$'`|
 |`version_tag_prefix`|a prefix to prepend to the detected version number to create the tag (e.g. "v")|no|`''`|
 |`annotated`|whether to create an annotated tag, using the commit body as the message|no|`false`|
 |`dry_run`|do everything except actually create the tag|no|`false`|

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   version_regex:
     description: 'The version regex to use for detecting version in commit messages'
     required: false
-    default: '[0-9]+.[0-9]+.[0-9]+'
+    default: '^[0-9]+\.[0-9]+\.[0-9]+$'
   version_tag_prefix:
     description: 'A prefix to prepend to the detected version number to create the tag (e.g. "v")'
     required: false


### PR DESCRIPTION
Closes #5

I've had to escape the backslashes in the tests. Not sure if I should escape the ones in `action.yml`. However, I tested it [here](https://github.com/christophebedard/tag-version-commit/runs/693808935) (commit title "8a7a6" and I modified the CI config to run on that branch) and it does not create a tag (which is correct). And according to [this](http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html), a backslash doesn't need to be escaped in a YAML string.