### PR TITLE
Assert version in package-lock.json as well

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: ./
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        version_assertion_command: 'grep -q "\"version\": \"$version\"" package.json'
+        version_assertion_command: 'grep -q "\"version\": \"$version\"" package.json && grep -q "^  \"version\": \"$version\"" package-lock.json'
         version_tag_prefix: 'v'
         annotated: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
     - uses: ./
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        version_assertion_command: 'grep -q "\"version\": \"$version\"" package.json'
+        version_assertion_command: 'grep -q "\"version\": \"$version\"" package.json && grep -q "^  \"version\": \"$version\"" package-lock.json'
         dry_run: true


### PR DESCRIPTION
In order to keep it in sync.

Note that `^  ` is needed at the beginning of the regex because there are many `"version": "a.b.c"` in a `package-lock.json`. Checking for only two spaces makes sure that we are only asserting the version of the package itself and not the version of any dependencies.