### PR TITLE
Allow checking whole commit message and not just title

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - 'releases/*'
 
 jobs:
   tag:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ on:
   push:
     branches:
       - master
-      - 'releases/*'
 jobs:
   tag:
     runs-on: ubuntu-latest
@@ -102,7 +101,6 @@ on:
   push:
     branches:
       - master
-      - 'releases/*'
 jobs:
   tag:
     runs-on: ubuntu-latest
@@ -125,7 +123,6 @@ on:
   push:
     branches:
       - master
-      - 'releases/*'
 jobs:
   tag:
     runs-on: ubuntu-latest
@@ -184,7 +181,7 @@ jobs:
 |:---|:----------|:-----:|
 |`tag`|the tag that has been created|`''`|
 |`message`|the message of the annotated tag (if `annotated`) that has been created|`''`|
-|`commit`|the commit that was tagged|`''`|
+|`commit`|the commit hash that was tagged|`''`|
 
 &nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp; if no tag has been created (unless `dry_run` is enabled)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ GitHub action for tagging commits whose title matches a version regex.
       1. [Use a capture group](#Use-a-capture-group)
       1. [Compare matched version with content of file(s)](#Compare-matched-version-with-content-of-files)
       1. [Use a version tag prefix](#Use-a-version-tag-prefix)
+      1. [Check entire commit message for matching version](#Check-entire-commit-message-for-matching-version)
 1. [Inputs](#Inputs)
 1. [Outputs](#Outputs)
 1. [Contributing](#Contributing)
@@ -116,7 +117,7 @@ jobs:
 #### Use a version tag prefix
 
 Use a prefix for the version tag, e.g. `v`.
-This would create a `v1.2.3` tag for a commit titled `1.2.3`.
+For example, this would create a `v1.2.3` tag for a commit titled `1.2.3`.
 
 ```yaml
 name: 'tag'
@@ -136,6 +137,29 @@ jobs:
         version_tag_prefix: 'v'
 ```
 
+#### Check entire commit message for matching version
+
+Check the entire commit message for a version matching the regex, and not just the commit title.
+For example, this would create a `1.2.3` tag for a commit message (body or title) containing `Version: 1.2.3`.
+
+```yaml
+name: 'tag'
+on:
+  push:
+    branches:
+      - master
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: christophebedard/tag-version-commit@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        version_regex: 'Version: ([0-9]+\.[0-9]+\.[0-9]+)'
+        check_entire_commit_message: true
+```
+
 ## Inputs
 
 |Name|Description|Required|Default|
@@ -144,6 +168,7 @@ jobs:
 |`version_regex`|the version regex to use for detecting version in commit messages; can contain either 0 or 1 capture group<sup>2</sup>|no|`'^[0-9]+\.[0-9]+\.[0-9]+$'`|
 |`version_assertion_command`<sup>3</sup>|a command to run to validate the version, e.g. compare against a version file|no|`''`|
 |`version_tag_prefix`|a prefix to prepend to the detected version number to create the tag (e.g. "v")|no|`''`|
+|`check_entire_commit_message`|whether to check the entire commit message, not just the title, for a matching version|no|`false`|
 |`annotated`|whether to create an annotated tag, using the commit body as the message|no|`false`|
 |`dry_run`|do everything except actually create the tag|no|`false`|
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   process.env['INPUT_VERSION_REGEX'] = '^[0-9]+\\.[0-9]+\\.[0-9]+$';
   process.env['INPUT_VERSION_TAG_PREFIX'] = '';
   process.env['INPUT_VERSION_ASSERTION_COMMAND'] = '';
+  process.env['INPUT_CHECK_ENTIRE_COMMIT_MESSAGE'] = 'false';
   process.env['INPUT_ANNOTATED'] = 'false';
   process.env['INPUT_DRY_RUN'] = 'false';
   // Set token to simplify tests
@@ -290,6 +291,69 @@ describe('action', () => {
     expect(stdout_write).toHaveBeenCalledWith(
       expect.stringContaining('::error::Version assertion failed')
     );
+  });
+
+  it('checks the entire commit message for a matching version if the option is enabled', async () => {
+    process.env['INPUT_VERSION_REGEX'] = String.raw`Version: ([0-9]+\.[0-9]+\.[0-9]+)`;
+    process.env['INPUT_CHECK_ENTIRE_COMMIT_MESSAGE'] = 'true';
+
+    nock('https://api.github.com')
+      .get('/repos/theowner/therepo/git/commits/0123456789abcdef')
+      .reply(200, {
+        message: 'Tag new version\n\nVersion: 1.5.2\nsome more commit body text'
+      });
+    nock('https://api.github.com')
+      .post('/repos/theowner/therepo/git/refs', {ref: 'refs/tags/1.5.2', sha: '0123456789abcdef'})
+      .reply(201, {});
+
+    const stdout_write = jest.spyOn(process.stdout, 'write');
+
+    await run();
+
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringContaining('name=tag::1.5.2'));
+    expect(stdout_write).toHaveBeenCalledWith(
+      expect.stringContaining('name=commit::0123456789abcdef')
+    );
+  });
+
+  it('does not check the entire commit message for a matching version if the option is disabled', async () => {
+    process.env['INPUT_VERSION_REGEX'] = String.raw`Version: ([0-9]+\.[0-9]+\.[0-9]+)`;
+    process.env['INPUT_CHECK_ENTIRE_COMMIT_MESSAGE'] = 'false';
+
+    nock('https://api.github.com')
+      .get('/repos/theowner/therepo/git/commits/0123456789abcdef')
+      .reply(200, {
+        message: 'Tag new version\n\nVersion: 1.5.3\nsome more commit body text'
+      });
+
+    const stdout_write = jest.spyOn(process.stdout, 'write');
+
+    await run();
+
+    // Outputs should be empty
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
+  });
+
+  it('does not do anything if there is no match when the option for checking entire commit message is enabled', async () => {
+    process.env['INPUT_VERSION_REGEX'] = String.raw`Version: ([0-9]+\.[0-9]+\.[0-9]+)`;
+    process.env['INPUT_CHECK_ENTIRE_COMMIT_MESSAGE'] = 'true';
+
+    nock('https://api.github.com')
+      .get('/repos/theowner/therepo/git/commits/0123456789abcdef')
+      .reply(200, {
+        message: 'Some commit title\n\nBlah blah\nsome more commit body text'
+      });
+
+    const stdout_write = jest.spyOn(process.stdout, 'write');
+
+    await run();
+
+    // Outputs should be empty
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
   it('creates an annotated tag if the option is enabled', async () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -64,6 +64,7 @@ describe('action', () => {
 
     // Outputs should be empty
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
@@ -80,6 +81,7 @@ describe('action', () => {
 
     // Outputs should be empty
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
@@ -97,6 +99,7 @@ describe('action', () => {
 
     // Outputs should be empty
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
@@ -211,6 +214,7 @@ describe('action', () => {
 
     // Outputs should be empty
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
@@ -227,6 +231,7 @@ describe('action', () => {
 
     // Outputs should be empty
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=tag::[\n]*$/));
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=message::[\n]*$/));
     expect(stdout_write).toHaveBeenCalledWith(expect.stringMatching(/^.*name=commit::[\n]*$/));
   });
 
@@ -284,13 +289,13 @@ describe('action', () => {
         message: '3.4.5'
       });
 
+    const core_setFailed = jest.spyOn(core, 'setFailed');
     const stdout_write = jest.spyOn(process.stdout, 'write');
 
     await run();
 
-    expect(stdout_write).toHaveBeenCalledWith(
-      expect.stringContaining('::error::Version assertion failed')
-    );
+    expect(core_setFailed).toHaveBeenCalled();
+    expect(stdout_write).toHaveBeenCalledWith(expect.stringContaining('Version assertion failed'));
   });
 
   it('checks the entire commit message for a matching version if the option is enabled', async () => {

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
       A prefix to prepend to the detected version number to create the tag (e.g. "v").
     required: false
     default: ''
+  check_entire_commit_message:
+    description: |
+      Check the entire commit message, not just the title, for a matching version.
+    required: false
+    default: 'false'
   annotated:
     description: |
       Whether to create an annotated tag, using the commit body as the message.


### PR DESCRIPTION
Through the `check_entire_commit_message` input.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>