### PR TITLE
Exclude dependabot's commits from DCO checking

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -18,4 +18,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip3 install -U dco-check
-        dco-check --verbose
+        dco-check --verbose --exclude-emails 49699333+dependabot[bot]@users.noreply.github.com


### PR DESCRIPTION
See https://github.com/christophebedard/dco-check/pull/115

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>